### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ emoji embeddings into your projects like so:
 ```
 import gensim.models as gsm
 
-e2v = gsm.Word2Vec.load_word2vec_format('emoji2vec.bin', binary=True)
+e2v = gsm.KeyedVectors.load_word2vec_format('emoji2vec.bin', binary=True)
 happy_vector = e2v['😂']    # Produces an embedding vector of length 300
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ object. Alternatively, you can provide two filenames to do so. Query
 like so:
 
 ```
-vec = phrase2Vec['I am really happy right now! 😄]
+vec = phrase2Vec['I am really happy right now! 😄']
 ```
 
 ## Train

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ object. Alternatively, you can provide two filenames to do so. Query
 like so:
 
 ```
-vec = phrase2Vec['I am really happy right now! 😄']
+vec = phrase2Vec['I am really happy right now! 😄]
 ```
 
 ## Train

--- a/model.py
+++ b/model.py
@@ -119,7 +119,7 @@ class Emoji2Vec:
         v_col = tf.nn.dropout(v_col, (1 - model_params.dropout))
 
         # Calculate the predicted score, a.k.a. dot product (here)
-        self.score = tf.reduce_sum(tf.mul(v_row, v_col), 1)
+        self.score = tf.reduce_sum(tf.multiply(v_row, v_col), 1)
 
         # Probability of match
         self.prob = tf.sigmoid(self.score)

--- a/model.py
+++ b/model.py
@@ -125,7 +125,7 @@ class Emoji2Vec:
         self.prob = tf.sigmoid(self.score)
 
         # Calculate the cross-entropy loss
-        self.loss = tf.nn.sigmoid_cross_entropy_with_logits(labels=self.score, logits=self.y)
+        self.loss = tf.nn.sigmoid_cross_entropy_with_logits(logits=self.score, labels=self.y)
 
     # train the model using the appropriate parameters
     def train(self, kb, hooks, session):

--- a/model.py
+++ b/model.py
@@ -250,7 +250,7 @@ class Emoji2Vec:
         vecs = sess.run(self.V)
         txt_path = model_folder + '/emoji2vec.txt'
         bin_path = model_folder + '/emoji2vec.bin'
-        f = open(txt_path, 'w')
+        f = open(txt_path, 'w', encoding="utf8)
         f.write('%d %d\n' % (len(vecs), out_dim))
         for i in range(len(vecs)):
             f.write(ind2emoj[i] + ' ')

--- a/model.py
+++ b/model.py
@@ -125,7 +125,7 @@ class Emoji2Vec:
         self.prob = tf.sigmoid(self.score)
 
         # Calculate the cross-entropy loss
-        self.loss = tf.nn.sigmoid_cross_entropy_with_logits(self.score, self.y)
+        self.loss = tf.nn.sigmoid_cross_entropy_with_logits(labels=self.score, logits=self.y)
 
     # train the model using the appropriate parameters
     def train(self, kb, hooks, session):

--- a/model.py
+++ b/model.py
@@ -250,7 +250,7 @@ class Emoji2Vec:
         vecs = sess.run(self.V)
         txt_path = model_folder + '/emoji2vec.txt'
         bin_path = model_folder + '/emoji2vec.bin'
-        f = open(txt_path, 'w', encoding="utf8)
+        f = open(txt_path, 'w', encoding="utf8")
         f.write('%d %d\n' % (len(vecs), out_dim))
         for i in range(len(vecs)):
             f.write(ind2emoj[i] + ' ')

--- a/model.py
+++ b/model.py
@@ -259,7 +259,7 @@ class Emoji2Vec:
             f.write('\n')
         f.close()
 
-        e2v = gs.Word2Vec.load_word2vec_format(txt_path, binary=False)
+        e2v = gs.KeyedVectors.load_word2vec_format(txt_path, binary=False)
         e2v.save_word2vec_format(bin_path, binary=True)
 
         return e2v

--- a/naga/shared/trainer.py
+++ b/naga/shared/trainer.py
@@ -20,7 +20,7 @@ class Trainer(object):
             session = tf.Session()
             close_session_after_training = True  # no session existed before, we provide a temporary session
 
-        init = tf.initialize_all_variables()
+        init = tf.global_variables_initializer()
         session.run(init)
         epoch = 1
         iteration = 1

--- a/phrase2vec.py
+++ b/phrase2vec.py
@@ -47,9 +47,9 @@ class Phrase2Vec:
             print(str.format('{} not found. Either provide a different path, or download binary from '
                              'https://code.google.com/archive/p/word2vec/ and unzip', w2v_path))
 
-        w2v = gs.Word2Vec.load_word2vec_format(w2v_path, binary=True)
+        w2v = gs.KeyedVectors.load_word2vec_format(w2v_path, binary=True)
         if e2v_path is not None:
-            e2v = gs.Word2Vec.load_word2vec_format(e2v_path, binary=True)
+            e2v = gs.KeyedVectors.load_word2vec_format(e2v_path, binary=True)
         else:
             e2v = dict()
         return cls(dim, w2v, e2v)

--- a/train.py
+++ b/train.py
@@ -101,7 +101,7 @@ def train_save_evaluate(params, kb, train_set, dev_set, ind2emoji, embeddings_ar
 
         else:
             # For visualizing using tensorboard
-            summary_writer = tf.train.SummaryWriter(model_folder + '/board', graph=sess.graph)
+            summary_writer = tf.summary.FileWriter(model_folder + '/board', graph=sess.graph)
 
             # Keep track of how the model is training
             hooks = [

--- a/utils.py
+++ b/utils.py
@@ -60,7 +60,7 @@ def generate_embeddings(ind2phr, kb, embeddings_file, word2vec_file, word2vec_di
 
 # Read data from a file and inject it into a knowledge base
 def __read_data(filename, base, ind_to_phr, ind_to_emoj, typ):
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding="utf8") as f:
         # build the data line by line
         lines = f.readlines()
         for line in lines:


### PR DESCRIPTION
`gensim.models.Word2Vec.load_word2vec_format` is deprecated, `gensim.models.KeyedVectors.load_word2vec_format` is used instead.